### PR TITLE
Fix private release tagging

### DIFF
--- a/nodeApps/createPrivateRelease.sh
+++ b/nodeApps/createPrivateRelease.sh
@@ -24,7 +24,7 @@ fi
 
 # Check if we have not release this version already
 git pull
-LAST_TAG=`git tag --list | grep '[0-9]' | sort | tail -n 1`
+LAST_TAG=`git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort | tail -n 1`
 echo "Last tag: ${LAST_TAG}"
 THIS_VERSION=`cat package.json | grep version | cut -d '"' -f 4`
 echo "This version: ${THIS_VERSION}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-helpers",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A collection of scripts that can be used as part of a deployment process.",
   "main": "",
   "scripts": {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

We have found a bug in our private npm release script. When we list the current tags in the repo we do not correctly filter out any `*-latest` tags so they can be chosen as the latest version. Which means the package.json's version will not match and the *-latest tag will be updated to the latest master.

#### What tests does this PR have?

None.

#### How can this be tested?

On this repo run the following old command:

    git tag --list | grep '[0-9]'

You'll see the `v1-latest` in the tag list.

Now run the updated command:

    git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'

You will now only see the individual version tags.

#### Screenshots / Screencast


#### What gif best describes how you feel about this work?

![giphy](https://cloud.githubusercontent.com/assets/3158640/14658283/847abbe0-068a-11e6-968d-22b41d2b5ea1.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** \*
- [x] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru