### PR TITLE
merge release scripts, tag each shortbreaks release as n1-latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,38 @@ This project holds various deployment scripts that are used with AWS CodeDeploy 
 
 ### `createPrivateRelease.sh`
 
-This will check if the `package.json` version has been updated for a project and then create a new release on github after running `npm build` and commiting any changed release assets in the `dist` directory.
+This will check if the `package.json` version has been updated for a project and then create a new release on github after running `npm build` and commiting any changed release assets in the `dist` directory.A
+Steps:
+ - Check credentials
+ - Check we are on the release branch
+ - Setup git environment
+ - Check if we have not release this version already
+ - Remove dist/ folder if it exists
+ - Build again, to recreate the dist/ folder
+ - Commit the dist/ folder if it exists
+ - Tag a new release with this version
+ - Delete the current tag for this major version, for example `v2.3.4`
+ - Tag a new release with this major version, for example `v2-latest`
+ - Optionally log to Graphite
+
+You must have environment vars `GITHUB_USER` and `GITHUB_API_TOKEN` set. If they're missing this will fall back to `GHUSER` and `GHPASS` - we should migrate all Short Breaks CI to use this script with the correct params and then remove this option.
+
+If you set evn var of `DEBUG` you can try out this script echoing instead of updating anything, for example
+```
+DEBUG=true RELEASE_BRANCH=lunchtime-larks GITHUB_USER=foo GITHUB_API_TOKEN=bar npm run release
+```
+
+#### optional params for createPrivateRelease.sh
+
+If you pass an extra param to the release script, and the relevant related environment vars are set (`GRAPHITE_API_KEY`, `BASE_NAME`, and `GRAPHITE_ENDPOINT_PREFIX`) then we will log this to graphite. Example (with debugging):
+```
+DEBUG=true RELEASE_BRANCH=lunchtime-larks GITHUB_USER=foo GITHUB_API_TOKEN=bar GRAPHITE_API_KEY=graphite npm run release -- PRODUCTION
+```
+
+If you pass in a second param of true then no data will be logged to graphite. Example (with debugging):
+```
+DEBUG=true RELEASE_BRANCH=lunchtime-larks GITHUB_USER=foo GITHUB_API_TOKEN=bar GRAPHITE_API_KEY=graphite npm run release -- PRODUCTION true
+```
 
 ### `cachedInstallModules.sh`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project holds various deployment scripts that are used with AWS CodeDeploy 
 
 ### `createPrivateRelease.sh`
 
-This will check if the `package.json` version has been updated for a project and then create a new release on github after running `npm build` and commiting any changed release assets in the `dist` directory.A
+This will check if the `package.json` version has been updated for a project and then create a new release on github after running `npm build` and commiting any changed release assets in the `dist` directory.
 Steps:
  - Check credentials
  - Check we are on the release branch

--- a/nodeApps/createPrivateRelease.sh
+++ b/nodeApps/createPrivateRelease.sh
@@ -4,6 +4,19 @@
 
 set -e
 
+ENVIRONMENT=$1
+NO_METRIC=$2
+if [ $DEBUG != "" ]; then
+  SAFE_DEBUG_ECHO=echo
+fi
+
+# allow the core standard of $GITHUB_USER:$GITHUB_API_TOKEN or shortbreaks' $GHUSER:$GHPASS
+if [ -z $GITHUB_USER ]; then
+  GITHUB_USER=$GHUSER
+fi
+if [ -z $GITHUB_API_TOKEN ]; then
+  GITHUB_API_TOKEN=$GHPASS
+fi
 if [ "${GITHUB_USER}" == "" ] || [ "${GITHUB_API_TOKEN}" == "" ]; then
   echo "ERROR: GitHub credentials not set."
   exit 1
@@ -21,7 +34,9 @@ if [ "`git config --get user.name`" == "" ]; then
 fi
 
 # Check if we are on the correct branch to release from
-RELEASE_BRANCH="master"
+if [ "${RELEASE_BRANCH}" == "" ]; then
+  RELEASE_BRANCH="master"
+fi
 if [ "${TRAVIS_BRANCH}" != "" ]; then
   CURRENT_BRANCH=${TRAVIS_BRANCH}
 else
@@ -37,7 +52,10 @@ fi
 git pull
 LAST_TAG=`git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort | tail -n 1`
 echo "Last tag: ${LAST_TAG}"
-THIS_VERSION=`cat package.json | grep version | head -n 1 | cut -d '"' -f 4`
+THIS_VERSION=${npm_package_version}
+if [ "v${THIS_VERSION}" == "" ]; then
+  THIS_VERSION=`cat package.json | grep version | head -n 1 | cut -d '"' -f 4`
+fi
 echo "This version: ${THIS_VERSION}"
 if [ "v${THIS_VERSION}" == "${LAST_TAG}" ]; then
   echo "WARNING: Version not updated"
@@ -49,7 +67,7 @@ git branch
 if [ -d dist ]; then
   git rm dist -r
 fi
-npm run build
+npm run build || echo "npm run build failed, but maybe there is no build script?"
 # If a new dist dir has been built we may need to commit it
 if [ -d dist ]; then
   git add dist
@@ -62,7 +80,13 @@ if [ -d dist ]; then
 fi
 
 # Determine name of the project
-REPO_OWNER="holidayextras"
+REPO_OWNER=`echo "${npm_package_repository_url}" | cut -d/ -f4`
+# if this has been run as an npm script then we have everything we need, but...
+if [ -z $REPO_OWNER ]; then
+  echo could not get env vars, are you running this as an npm script?
+  # imo we should die here but, for backward compatibility
+  REPO_OWNER="holidayextras"
+fi
 if [ "${CIRCLE_BUILD_NUM}" != "" ]; then
   APP_NAME="${REPO_OWNER}/${CIRCLE_PROJECT_REPONAME}"
 elif [ "${TRAVIS_JOB_NUMBER}" != "" ]; then
@@ -88,7 +112,7 @@ echo "Latest commit is: ${CURRENT_SHA}"
 # Tag this deploy and make a release in github
 RELEASE_JSON="{\"tag_name\": \"v${THIS_VERSION}\",\"target_commitish\": \"${CURRENT_SHA}\",\"name\": \"v${THIS_VERSION}\",\"body\": \"${MESSAGE}\",\"draft\": false,\"prerelease\": false}"
 echo "Release JSON: ${RELEASE_JSON}"
-curl -u "${GITHUB_USER}:${GITHUB_API_TOKEN}" --data "${RELEASE_JSON}" https://api.github.com/repos/${APP_NAME}/releases
+$SAFE_DEBUG_ECHO curl -u "${GITHUB_USER}:${GITHUB_API_TOKEN}" --data "${RELEASE_JSON}" https://api.github.com/repos/${APP_NAME}/releases
 
 # Now update the major release tag
 
@@ -96,9 +120,17 @@ THIS_MAJOR_VERSION=`echo ${THIS_VERSION} | grep -E -o '^[0-9]+'`
 echo "Major version: ${THIS_MAJOR_VERSION}"
 
 # Delete current tag if any
-curl -u "${GITHUB_USER}:${GITHUB_API_TOKEN}" -X DELETE https://api.github.com/repos/${APP_NAME}/git/refs/tags/v${THIS_MAJOR_VERSION}-latest
+$SAFE_DEBUG_ECHO curl -u "${GITHUB_USER}:${GITHUB_API_TOKEN}" -X DELETE https://api.github.com/repos/${APP_NAME}/git/refs/tags/v${THIS_MAJOR_VERSION}-latest
 
 # Create a new updated tag
-curl -u "${GITHUB_USER}:${GITHUB_API_TOKEN}" --data "{\"ref\": \"refs/tags/v${THIS_MAJOR_VERSION}-latest\",\"sha\": \"${CURRENT_SHA}\"}" https://api.github.com/repos/${APP_NAME}/git/refs
+$SAFE_DEBUG_ECHO curl -u "${GITHUB_USER}:${GITHUB_API_TOKEN}" --data "{\"ref\": \"refs/tags/v${THIS_MAJOR_VERSION}-latest\",\"sha\": \"${CURRENT_SHA}\"}" https://api.github.com/repos/${APP_NAME}/git/refs
+
+# Add a deployment counter in the metrics platform (graphite)
+if [ "$ENVIRONMENT" != "" } && [ "${GRAPHITE_API_KEY}" != "" ] && [ -z $NO_METRIC ]; then
+  if [ $DEBUG != "" ]; then
+	  echo "${GRAPHITE_API_KEY}.counters.${BASE_NAME}.${ENVIRONMENT}.inf.deployment 1 |"
+  fi
+	echo "${GRAPHITE_API_KEY}.counters.${BASE_NAME}.${ENVIRONMENT}.inf.deployment 1" | $SAFE_DEBUG_ECHO nc ${GRAPHITE_ENDPOINT_PREFIX}.carbon.hostedgraphite.com 2003
+fi
 
 echo -e "\n\nDone."

--- a/nodeApps/createPrivateRelease.sh
+++ b/nodeApps/createPrivateRelease.sh
@@ -128,9 +128,9 @@ $SAFE_DEBUG_ECHO curl -u "${GITHUB_USER}:${GITHUB_API_TOKEN}" --data "{\"ref\": 
 # Add a deployment counter in the metrics platform (graphite)
 if [ "$ENVIRONMENT" != "" } && [ "${GRAPHITE_API_KEY}" != "" ] && [ -z $NO_METRIC ]; then
   if [ $DEBUG != "" ]; then
-	  echo "${GRAPHITE_API_KEY}.counters.${BASE_NAME}.${ENVIRONMENT}.inf.deployment 1 |"
+    echo "${GRAPHITE_API_KEY}.counters.${BASE_NAME}.${ENVIRONMENT}.inf.deployment 1 |"
   fi
-	echo "${GRAPHITE_API_KEY}.counters.${BASE_NAME}.${ENVIRONMENT}.inf.deployment 1" | $SAFE_DEBUG_ECHO nc ${GRAPHITE_ENDPOINT_PREFIX}.carbon.hostedgraphite.com 2003
+  echo "${GRAPHITE_API_KEY}.counters.${BASE_NAME}.${ENVIRONMENT}.inf.deployment 1" | $SAFE_DEBUG_ECHO nc ${GRAPHITE_ENDPOINT_PREFIX}.carbon.hostedgraphite.com 2003
 fi
 
 echo -e "\n\nDone."

--- a/nodeApps/createPrivateRelease.sh
+++ b/nodeApps/createPrivateRelease.sh
@@ -100,7 +100,7 @@ fi
 # Set a sensible release message
 MESSAGE="NPM release by developer."
 if [ "${CIRCLE_BUILD_NUM}" != "" ]; then
-  MESSAGE="NPM release via CI build: [${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${APP_NAME}/${CIRCLE_BUILD_NUM})."
+  MESSAGE="NPM release by ${CIRCLE_USERNAME} via CI build: [${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${APP_NAME}/${CIRCLE_BUILD_NUM})."
 elif [ "${TRAVIS_JOB_NUMBER}" != "" ]; then
   MESSAGE="NPM release via CI build: [${TRAVIS_JOB_ID}](https://travis-ci.com/${APP_NAME}/jobs/${TRAVIS_JOB_ID})."
 fi

--- a/nodeApps/postRelease.sh
+++ b/nodeApps/postRelease.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-echo $0 is depracated please update to createPrivateRelease.sh instead
+echo $0 is deprecated please update to createPrivateRelease.sh instead
 pwd
 ${DIR}/createPrivateRelease.sh $1 $2
 exit 0

--- a/nodeApps/postRelease.sh
+++ b/nodeApps/postRelease.sh
@@ -1,13 +1,39 @@
 #!/bin/bash -e
-APP_NAME="`cat package.json | grep -m 1 name | cut -d '"' -f 4`"
-CANDIDATE_VERSION=`cat package.json | grep version | cut -d '"' -f 4`
-REPO_OWNER="holidayextras"
+APP_NAME=$npm_package_name
+CANDIDATE_VERSION=$npm_package_version
+REPO_OWNER=`echo ${npm_package_repository_url} | cut -d/ -f4`
+# if this has been run as an npm script then we have everything we need, but...
+if [ -z $REPO_OWNER ] || [ -z $CANDIDATE_VERSION ] || [ -z $APP_NAME ]; then
+  echo could not get env vars, are you running this as an npm script?
+  # imo we should die here but, for backward compatibility
+  REPO_OWNER="holidayextras"
+  APP_NAME="`cat package.json | grep -m 1 name | cut -d '"' -f 4`"
+  CANDIDATE_VERSION=`cat package.json | grep version | cut -d '"' -f 4`
+fi
 ENVIRONMENT=$1
 NO_METRIC=$2
 
-if [ $ENVIRONMENT = "production" ] || [ $ENVIRONMENT = "master" ]; then
+# allow the core standard of $GITHUB_USER:$GITHUB_API_TOKEN or shortbreaks' $GHUSER:$GHPASS
+if [ -z $GITHUB_USER ]; then
+  GITHUB_USER=$GHUSER
+fi
+if [ -z $GITHUB_API_TOKEN ]; then
+  GITHUB_USER=$GHPASS
+fi
+
+if [ "$ENVIRONMENT" == "production" ] || [ "$ENVIRONMENT" = "master" ]; then
 	# Tag this deploy and make a release in github
-	curl --user "${GHUSER}:${GHPASS}" --data "{\"tag_name\": \"v${CANDIDATE_VERSION}\",\"target_commitish\": \"master\",\"name\": \"v${CANDIDATE_VERSION}\",\"body\": \"Production release by @${CIRCLE_USERNAME} (via build: [${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${REPO_OWNER}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM})).\",\"draft\": false,\"prerelease\": false}" https://api.github.com/repos/${REPO_OWNER}/${CIRCLE_PROJECT_REPONAME}/releases
+	curl --user "${GITHUB_USER}:${GITHUB_API_TOKEN}" --data "{\"tag_name\": \"v${CANDIDATE_VERSION}\",\"target_commitish\": \"master\",\"name\": \"v${CANDIDATE_VERSION}\",\"body\": \"Production release by @${CIRCLE_USERNAME} (via build: [${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${REPO_OWNER}/${APP_NAME}/${CIRCLE_BUILD_NUM})).\",\"draft\": false,\"prerelease\": false}" https://api.github.com/repos/${REPO_OWNER}/${APP_NAME}/releases
+
+  THIS_MAJOR_VERSION=`echo ${CANDIDATE_VERSION} | grep -E -o '^[0-9]+'`
+  echo "Major version: ${THIS_MAJOR_VERSION}"
+  
+  # Delete current tag if any
+  curl -u "${GITHUB_USER}:${GITHUB_API_TOKEN}" -X DELETE https://api.github.com/repos/${APP_NAME}/git/refs/tags/v${THIS_MAJOR_VERSION}-latest
+  
+  # Create a new updated tag
+  curl -u "${GITHUB_USER}:${GITHUB_API_TOKEN}" --data "{\"ref\": \"refs/tags/v${THIS_MAJOR_VERSION}-latest\",\"sha\": \"${CURRENT_SHA}\"}" https://api.github.com/repos/${APP_NAME}/git/refs
+
 fi
 # Add a deployment counter in the metrics platform (graphite)
 if [ -z $NO_METRIC ]; then

--- a/nodeApps/postRelease.sh
+++ b/nodeApps/postRelease.sh
@@ -1,41 +1,7 @@
 #!/bin/bash -e
-APP_NAME=$npm_package_name
-CANDIDATE_VERSION=$npm_package_version
-REPO_OWNER=`echo ${npm_package_repository_url} | cut -d/ -f4`
-# if this has been run as an npm script then we have everything we need, but...
-if [ -z $REPO_OWNER ] || [ -z $CANDIDATE_VERSION ] || [ -z $APP_NAME ]; then
-  echo could not get env vars, are you running this as an npm script?
-  # imo we should die here but, for backward compatibility
-  REPO_OWNER="holidayextras"
-  APP_NAME="`cat package.json | grep -m 1 name | cut -d '"' -f 4`"
-  CANDIDATE_VERSION=`cat package.json | grep version | cut -d '"' -f 4`
-fi
-ENVIRONMENT=$1
-NO_METRIC=$2
 
-# allow the core standard of $GITHUB_USER:$GITHUB_API_TOKEN or shortbreaks' $GHUSER:$GHPASS
-if [ -z $GITHUB_USER ]; then
-  GITHUB_USER=$GHUSER
-fi
-if [ -z $GITHUB_API_TOKEN ]; then
-  GITHUB_USER=$GHPASS
-fi
-
-if [ "$ENVIRONMENT" == "production" ] || [ "$ENVIRONMENT" = "master" ]; then
-	# Tag this deploy and make a release in github
-	curl --user "${GITHUB_USER}:${GITHUB_API_TOKEN}" --data "{\"tag_name\": \"v${CANDIDATE_VERSION}\",\"target_commitish\": \"master\",\"name\": \"v${CANDIDATE_VERSION}\",\"body\": \"Production release by @${CIRCLE_USERNAME} (via build: [${CIRCLE_BUILD_NUM}](https://circleci.com/gh/${REPO_OWNER}/${APP_NAME}/${CIRCLE_BUILD_NUM})).\",\"draft\": false,\"prerelease\": false}" https://api.github.com/repos/${REPO_OWNER}/${APP_NAME}/releases
-
-  THIS_MAJOR_VERSION=`echo ${CANDIDATE_VERSION} | grep -E -o '^[0-9]+'`
-  echo "Major version: ${THIS_MAJOR_VERSION}"
-  
-  # Delete current tag if any
-  curl -u "${GITHUB_USER}:${GITHUB_API_TOKEN}" -X DELETE https://api.github.com/repos/${APP_NAME}/git/refs/tags/v${THIS_MAJOR_VERSION}-latest
-  
-  # Create a new updated tag
-  curl -u "${GITHUB_USER}:${GITHUB_API_TOKEN}" --data "{\"ref\": \"refs/tags/v${THIS_MAJOR_VERSION}-latest\",\"sha\": \"${CURRENT_SHA}\"}" https://api.github.com/repos/${APP_NAME}/git/refs
-
-fi
-# Add a deployment counter in the metrics platform (graphite)
-if [ -z $NO_METRIC ]; then
-	echo "${GRAPHITE_API_KEY}.counters.${APP_NAME}.${ENVIRONMENT}.inf.deployment 1" | nc ${GRAPHITE_ENDPOINT_PREFIX}.carbon.hostedgraphite.com 2003
-fi
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo $0 is depracated please update to createPrivateRelease.sh instead
+pwd
+${DIR}/createPrivateRelease.sh $1 $2
+exit 0

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "deployment-helpers",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "A collection of scripts that can be used as part of a deployment process.",
   "main": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postrelease": "nodeApps/postRelease.sh"
+    "release": "nodeApps/postRelease.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A collection of scripts that can be used as part of a deployment process.",
   "main": "",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postrelease": "nodeApps/postRelease.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### What are the links to relevant tickets?

https://hxshortbreaks.atlassian.net/browse/WEB-7736
#### What does this PR do?

merges createPrivateRelease.sh with short breaks' postRelease.sh so that when we run postRelease.sh it will tag the latest release for this version as vn-latest so we can install the latest release for any major version. This means we can safely require the latest v1 of a repo without worry about breaking changes.

This brings short breaks and core into alignment in this area too 💒 
#### What functional/unit tests does this PR have?

none
#### Is there anything a developer should be aware of when reviewing this?

you can run this locally with either `npm run release production 1` or `./nodeApps/postRelease.sh production 1` - ideally it would be run always as an npm script it's cleaner then, but leaving the fall back in for now.

To run this you need GHUSER or GITHUB_USER and GHPASS or GITHUB_API_TOKEN env vars (optionally plus others for short breaks graphite logging). Also you'd need to override the release branch so and you're debugging so don't actually `curl` anything just echo instead

```
DEBUG=true RELEASE_BRANCH=lunchtime-larks GITHUB_USER=foo GITHUB_API_TOKEN=bar npm run release
```

where `lunchtime-larks` is this branch.

It's a simple change but it would be nice to be able to do npm style `^` requiring of our github repos in short breaks and it brings sb + core closer together (group hug).

To simplify this and move to a single set of variables we need to either move from `GHUSER` and `GHPASS` to `GITHUB_USER` and `GITHUB_API_TOKEN` in each repo that uses the original postRelease.sh - this would carry on working fine without that migration though.

---
#### Quality checklist (for PR author to complete BEFORE code review):
- [ ] I've checked there is appropriate unit test coverage.
- [ ] I've updated documentation with any changes to procedures.
- [x] I've checked this work against the requirements of the Jira.
- [ ] This change passes all necessary tests (cross browser, automated or otherwise).
- [x] I am ready for this to be code reviewed, merged and tested.
#### Reviewer 1
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!
#### Reviewer 2
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!
