### PR TITLE
Optional "dist" directory

### DIFF
--- a/nodeApps/createPrivateRelease.sh
+++ b/nodeApps/createPrivateRelease.sh
@@ -39,12 +39,15 @@ if [ -d dist ]; then
   git rm dist -r
 fi
 npm run build
-git add dist
-git status
-if [[ -n $(git status -s) ]] ; then
-  echo "Updated dist needs committing"
-  git commit -m "Added new dist for version ${THIS_VERSION}"
-  git push origin ${RELEASE_BRANCH}
+# If a new dist dir has been built we may need to commit it
+if [ -d dist ]; then
+  git add dist
+  git status
+  if [[ -n $(git status -s) ]] ; then
+    echo "Updated dist needs committing"
+    git commit -m "Added new dist for version ${THIS_VERSION}"
+    git push origin ${RELEASE_BRANCH}
+  fi
 fi
 
 # Determine name of the project

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-helpers",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A collection of scripts that can be used as part of a deployment process.",
   "main": "",
   "scripts": {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

This allows projects that do not store files in the `dist` directory to still create private releases.

#### What tests does this PR have?

None.

#### How can this be tested?

None.

#### Any tech debt?

None.

#### Screenshots / Screencast

#### What gif best describes how you feel about this work?

![giphy](https://cloud.githubusercontent.com/assets/3158640/16710420/4dcef1e4-4625-11e6-8cd4-817b5759f384.gif)

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

---

**Notes**

When reviewing Static Site Generator projects, please think carefully about what can be done to centralise common functionality. Please also pay attention to anything configurable that will also need updating in the Yeoman generator template

---

**Reviewer**
- [x] :+1:
- [x] I don't think this PR needs any additional reviewers

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
