### PR TITLE
Ignore the error if a build script is missing

### DIFF
--- a/nodeApps/createPrivateRelease.sh
+++ b/nodeApps/createPrivateRelease.sh
@@ -50,8 +50,7 @@ if [ -d dist ]; then
   git rm dist -r
 fi
 
-HASBUILDSCRIPT=`npm run | grep '^  build$'`
-if [ ! -z "${HASBUILDSCRIPT}" ]; then
+if [ ! -z `npm run | grep '^  build$'` ]; then
   npm run build
 fi
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-helpers",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A collection of scripts that can be used as part of a deployment process.",
   "main": "",
   "scripts": {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

Rather than exiting the release script if no npm build command exists, this script will now continue as it does not require it in order to produce releases.

#### What tests does this PR have?

None.

#### How can this be tested?

Manually

#### Any tech debt?

#### Screenshots / Screencast

#### What gif best describes how you feel about this work?
![]()

- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
