### PR TITLE
Adding SBP ECS deploy helpers

### DIFF
--- a/ECS/SBP/deploy.sh
+++ b/ECS/SBP/deploy.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
-while getopts ":c:m:p:" opt; do
+DESIRED_COUNT=1
+while getopts ":c:m:p:i:" opt; do
   case $opt in
     c) CPU="$OPTARG"
     ;;
+    i) DESIRED_COUNT=$OPTARG
+	;;
     m) MEMORY="$OPTARG"
     ;;
     p) PORT="$OPTARG"
@@ -16,14 +19,14 @@ done
 echo "CPU=${CPU}"
 echo "MEMORY=${MEMORY}"
 echo "PORT=${PORT}"
+echo "DESIRED_COUNT=${DESIRED_COUNT}"
 
-VPC_ID="vpc-9f48f7fa"
-VPC_SUBNETS="subnet-7916a320 subnet-a69af1c3 subnet-e1a03396"
-VPC_SECURITY_GROUPS="sg-cad732ad"
+VPC_ID="${AWS_VPC_ID}"
+VPC_SUBNETS="${AWS_VPC_SUBNETS}"
+VPC_SECURITY_GROUPS="${AWS_VPC_SECURITY_GROUPS}"
 
 SERVICE_NAME="`cat package.json | grep -m 1 name | cut -d '"' -f 4`"
 CLUSTER_NAME="SBP-Cluster-1"
-DESIRED_COUNT=1
 IMAGE_TAG=${CIRCLE_SHA1:-latest}
 TEMPLATE_FILE="$(dirname "$0")/ecs-task-definition"
 $(aws ecr get-login --region eu-west-1)
@@ -48,16 +51,16 @@ SERVICE_RESPONSE=`aws ecs describe-services --cluster ${CLUSTER_NAME} --services
 echo "SERVICE_RESPONSE: ${SERVICE_RESPONSE}"
 if [[ ${SERVICE_RESPONSE} = "MISSING" ]]; then
 	if [ -z "${PORT}" ]; then
-		echo "SERVICE: `aws ecs create-service --cluster ${CLUSTER_NAME} --task-definition ${SERVICE_NAME}:${TASK_REVISION} --desired-count ${DESIRED_COUNT} --service-name ${SERVICE_NAME} --query service.status --output text`"
+		echo "CREATE SERVICE: `aws ecs create-service --cluster ${CLUSTER_NAME} --task-definition ${SERVICE_NAME}:${TASK_REVISION} --desired-count ${DESIRED_COUNT} --service-name ${SERVICE_NAME} --query service.status --output text`"
 	else
-		ALB_ARN=`aws elbv2 create-load-balancer --name ${SERVICE_NAME} --subnets ${VPC_SUBNETS} --security-groups ${VPC_SECURITY_GROUPS} --query LoadBalancers[0].LoadBalancerArn --output text`
-		echo "ALB_ARN: ${ALB_ARN}"
-		TARGET_ARN=`aws elbv2 create-target-group --name ${SERVICE_NAME} --protocol HTTP --port 80 --vpc-id ${VPC_ID} --query TargetGroups[0].TargetGroupArn --output text`
-		echo "TARGET_ARN: ${TARGET_ARN}"		
-		echo "CREATE_LISTNER: `aws elbv2 create-listener --load-balancer-arn ${ALB_ARN} --protocol HTTP --port 80 --default-actions Type=forward,TargetGroupArn=${TARGET_ARN} --query Listners[0].ListnerArn --output text`"
-		echo "SERVICE: `aws ecs create-service --cluster ${CLUSTER_NAME} --task-definition ${SERVICE_NAME}:${TASK_REVISION} --desired-count ${DESIRED_COUNT} --service-name ${SERVICE_NAME} --role ecsServiceRole --load-balancers targetGroupArn=${TARGET_ARN},containerName=${SERVICE_NAME},containerPort=${PORT} --query service.status --output text`"
-		echo "Application URL: http://`aws elbv2 describe-load-balancers --load-balancer-arns ${ALB_ARN} --query LoadBalancers[0].DNSName --output text`"
+		APPLICATION_LOAD_BALANCER_ARN=`aws elbv2 create-load-balancer --name ${SERVICE_NAME} --subnets ${VPC_SUBNETS} --security-groups ${VPC_SECURITY_GROUPS} --query LoadBalancers[0].LoadBalancerArn --output text`
+		echo "APPLICATION_LOAD_BALANCER_ARN: ${APPLICATION_LOAD_BALANCER_ARN}"
+		TARGET_GROUP_ARN=`aws elbv2 create-target-group --name ${SERVICE_NAME} --protocol HTTP --port 80 --vpc-id ${VPC_ID} --query TargetGroups[0].TargetGroupArn --output text`
+		echo "TARGET_GROUP_ARN: ${TARGET_GROUP_ARN}"
+		echo "CREATE LISTNER: `aws elbv2 create-listener --load-balancer-arn ${APPLICATION_LOAD_BALANCER_ARN} --protocol HTTP --port 80 --default-actions Type=forward,TargetGroupArn=${TARGET_GROUP_ARN} --query Listners[0].ListnerArn --output text`"
+		echo "CREATE SERVICE: `aws ecs create-service --cluster ${CLUSTER_NAME} --task-definition ${SERVICE_NAME}:${TASK_REVISION} --desired-count ${DESIRED_COUNT} --service-name ${SERVICE_NAME} --role ecsServiceRole --load-balancers targetGroupArn=${TARGET_GROUP_ARN},containerName=${SERVICE_NAME},containerPort=${PORT} --query service.status --output text`"
+		echo "Application URL: http://`aws elbv2 describe-load-balancers --load-balancer-arns ${APPLICATION_LOAD_BALANCER_ARN} --query LoadBalancers[0].DNSName --output text`"
 	fi
 else
-	echo "UPDATE_SERVICE: `aws ecs update-service --cluster ${CLUSTER_NAME} --task-definition ${SERVICE_NAME}:${TASK_REVISION} --desired-count ${DESIRED_COUNT} --service ${SERVICE_NAME} --query service.status --output text`"
+	echo "UPDATE SERVICE: `aws ecs update-service --cluster ${CLUSTER_NAME} --task-definition ${SERVICE_NAME}:${TASK_REVISION} --desired-count ${DESIRED_COUNT} --service ${SERVICE_NAME} --query service.status --output text`"
 fi

--- a/ECS/SBP/deploy.sh
+++ b/ECS/SBP/deploy.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+while getopts ":c:m:p:" opt; do
+  case $opt in
+    c) CPU="$OPTARG"
+    ;;
+    m) MEMORY="$OPTARG"
+    ;;
+    p) PORT="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    ;;
+  esac
+done
+
+echo "CPU=${CPU}"
+echo "MEMORY=${MEMORY}"
+echo "PORT=${PORT}"
+
+VPC_ID="vpc-9f48f7fa"
+VPC_SUBNETS="subnet-7916a320 subnet-a69af1c3 subnet-e1a03396"
+VPC_SECURITY_GROUPS="sg-cad732ad"
+
+SERVICE_NAME="`cat package.json | grep -m 1 name | cut -d '"' -f 4`"
+CLUSTER_NAME="SBP-Cluster-1"
+DESIRED_COUNT=1
+IMAGE_TAG=${CIRCLE_SHA1:-latest}
+TEMPLATE_FILE="ecs-task-definition"
+$(aws ecr get-login --region eu-west-1)
+ECR_REPOS=`aws ecr describe-repositories --output text --query repositories[*].repositoryName`
+
+if [[ ${ECR_REPOS} != *"${SERVICE_NAME}"* ]]; then
+	echo "REPOSITORY: `aws ecr create-repository --repository-name ${SERVICE_NAME} --query repository.repositoryUri --output text`"
+fi
+
+docker build -t ${SERVICE_NAME} .
+docker tag ${SERVICE_NAME} ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com/${SERVICE_NAME}:${IMAGE_TAG}
+docker push ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com/${SERVICE_NAME}:${IMAGE_TAG}
+
+if [ -n "${PORT}" ]; then
+	TEMPLATE_FILE="ecs-task-definition-exposedPorts"
+fi
+sed -e "s;%SERVICE_NAME%;${SERVICE_NAME};g" -e "s;%IMAGE_TAG%;${IMAGE_TAG};g" -e "s;%PORT%;${PORT};g" -e "s;%AWS_ACCOUNT_ID%;${AWS_ACCOUNT_ID};g" -e "s;%CPU%;${CPU};g" -e "s;%MEMORY%;${MEMORY};g" ${TEMPLATE_FILE}.json > taskDefinition.json
+echo "TASK: `aws ecs register-task-definition --family ${SERVICE_NAME} --cli-input-json file://taskDefinition.json --query taskDefinition.status --output text`"
+
+TASK_REVISION=`aws ecs describe-task-definition --task-definition ${SERVICE_NAME} --query taskDefinition.revision --output text`
+SERVICE_RESPONSE=`aws ecs describe-services --cluster ${CLUSTER_NAME} --services ${SERVICE_NAME} --query failures[0].reason --output text`
+echo "SERVICE_RESPONSE: ${SERVICE_RESPONSE}"
+if [[ ${SERVICE_RESPONSE} = "MISSING" ]]; then
+	if [ -z "${PORT}" ]; then
+		echo "SERVICE: `aws ecs create-service --cluster ${CLUSTER_NAME} --task-definition ${SERVICE_NAME}:${TASK_REVISION} --desired-count ${DESIRED_COUNT} --service-name ${SERVICE_NAME} --query service.status --output text`"
+	else
+		ALB_ARN=`aws elbv2 create-load-balancer --name ${SERVICE_NAME} --subnets ${VPC_SUBNETS} --security-groups ${VPC_SECURITY_GROUPS} --query LoadBalancers[0].LoadBalancerArn --output text`
+		echo "ALB_ARN: ${ALB_ARN}"
+		TARGET_ARN=`aws elbv2 create-target-group --name ${SERVICE_NAME} --protocol HTTP --port 80 --vpc-id ${VPC_ID} --query TargetGroups[0].TargetGroupArn --output text`
+		echo "TARGET_ARN: ${TARGET_ARN}"		
+		echo "CREATE_LISTNER: `aws elbv2 create-listener --load-balancer-arn ${ALB_ARN} --protocol HTTP --port 80 --default-actions Type=forward,TargetGroupArn=${TARGET_ARN} --query Listners[0].ListnerArn --output text`"
+		echo "SERVICE: `aws ecs create-service --cluster ${CLUSTER_NAME} --task-definition ${SERVICE_NAME}:${TASK_REVISION} --desired-count ${DESIRED_COUNT} --service-name ${SERVICE_NAME} --role ecsServiceRole --load-balancers targetGroupArn=${TARGET_ARN},containerName=${SERVICE_NAME},containerPort=${PORT} --query service.status --output text`"
+		echo "Application URL: http://`aws elbv2 describe-load-balancers --load-balancer-arns ${ALB_ARN} --query LoadBalancers[0].DNSName --output text`"
+	fi
+else
+	echo "UPDATE_SERVICE: `aws ecs update-service --cluster ${CLUSTER_NAME} --task-definition ${SERVICE_NAME}:${TASK_REVISION} --desired-count ${DESIRED_COUNT} --service ${SERVICE_NAME} --query service.status --output text`"
+fi

--- a/ECS/SBP/deploy.sh
+++ b/ECS/SBP/deploy.sh
@@ -25,7 +25,7 @@ SERVICE_NAME="`cat package.json | grep -m 1 name | cut -d '"' -f 4`"
 CLUSTER_NAME="SBP-Cluster-1"
 DESIRED_COUNT=1
 IMAGE_TAG=${CIRCLE_SHA1:-latest}
-TEMPLATE_FILE="ecs-task-definition"
+TEMPLATE_FILE="$(dirname "$0")/ecs-task-definition"
 $(aws ecr get-login --region eu-west-1)
 ECR_REPOS=`aws ecr describe-repositories --output text --query repositories[*].repositoryName`
 
@@ -38,7 +38,7 @@ docker tag ${SERVICE_NAME} ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com/${S
 docker push ${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com/${SERVICE_NAME}:${IMAGE_TAG}
 
 if [ -n "${PORT}" ]; then
-	TEMPLATE_FILE="ecs-task-definition-exposedPorts"
+	TEMPLATE_FILE="$(dirname "$0")/ecs-task-definition-exposedPorts"
 fi
 sed -e "s;%SERVICE_NAME%;${SERVICE_NAME};g" -e "s;%IMAGE_TAG%;${IMAGE_TAG};g" -e "s;%PORT%;${PORT};g" -e "s;%AWS_ACCOUNT_ID%;${AWS_ACCOUNT_ID};g" -e "s;%CPU%;${CPU};g" -e "s;%MEMORY%;${MEMORY};g" ${TEMPLATE_FILE}.json > taskDefinition.json
 echo "TASK: `aws ecs register-task-definition --family ${SERVICE_NAME} --cli-input-json file://taskDefinition.json --query taskDefinition.status --output text`"

--- a/ECS/SBP/ecs-task-definition-exposedPorts.json
+++ b/ECS/SBP/ecs-task-definition-exposedPorts.json
@@ -1,0 +1,24 @@
+{
+    "family": "%SERVICE_NAME%",
+    "containerDefinitions": [
+        {
+            "image": "%AWS_ACCOUNT_ID%.dkr.ecr.eu-west-1.amazonaws.com/%SERVICE_NAME%:%IMAGE_TAG%",
+            "name": "%SERVICE_NAME%",
+            "logConfiguration": {
+                "logDriver": "syslog",
+                "options": {
+                    "syslog-address": "udp://127.0.0.1:514"
+                }
+            },
+            "cpu": %CPU%,
+            "memory": %MEMORY%,
+            "essential": true,
+            "portMappings": [
+                {
+                    "containerPort": %PORT%,
+                    "protocol": "tcp"
+                }
+            ]
+        }
+    ]
+}

--- a/ECS/SBP/ecs-task-definition.json
+++ b/ECS/SBP/ecs-task-definition.json
@@ -1,0 +1,18 @@
+{
+    "family": "%SERVICE_NAME%",
+    "containerDefinitions": [
+        {
+            "image": "%AWS_ACCOUNT_ID%.dkr.ecr.eu-west-1.amazonaws.com/%SERVICE_NAME%:%IMAGE_TAG%",
+            "name": "%SERVICE_NAME%",
+            "logConfiguration": {
+                "logDriver": "syslog",
+                "options": {
+                    "syslog-address": "udp://127.0.0.1:514"
+                }
+            },
+            "cpu": %CPU%,
+            "memory": %MEMORY%,
+            "essential": true
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-helpers",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "A collection of scripts that can be used as part of a deployment process.",
   "main": "",
   "scripts": {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
Adds in generic deployment helper for the shortbreaks platform ECS cluster
#### What tests does this PR have?
N/A
#### How can this be tested?
From within an existing project you can run;
`./deploy.sh -c 128 -m 128 -p portNumber`
If you do not expose a port, do not pass in the `-p` flag.
P: Port
C: CPU units required
M: Memory required
#### Any tech debt?
This should eventually become part of the Node Toolkit
#### Screenshots / Screencast
N/A
#### What gif best describes how you feel about this work?
![](https://media.giphy.com/media/3oKIPnAiaMCws8nOsE/giphy.gif)

- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
