### PR TITLE
:wrench: fix relative path

### DIFF
--- a/nodeApps/generateSignedFile.js
+++ b/nodeApps/generateSignedFile.js
@@ -9,6 +9,7 @@ const git = require('simple-git')()
 const releaseBranch = process.env.releaseBranch || 'staging'
 const name = process.env.npm_package_name
 const version = process.env.npm_package_version
+const distPath = path.resolve(process.cwd(), '/dist')
 
 const checkPrerequisites = callback => {
   if (!process.env.npm_package_name) return callback('ERROR: run this as an npm script (npm run release)')
@@ -43,7 +44,7 @@ const checkBranch = callback => {
 }
 
 const checkAlreadyReleased = callback => {
-  const fullPath = path.resolve(__dirname, `../dist/${name}.min.${version}.js`)
+  const fullPath = path.resolve(`${distPath}/${name}.min.${version}.js`)
   if (fs.existsSync(fullPath)) {
     return callback(`Already exported ${name}.min.${version}.js`)
   }
@@ -67,8 +68,8 @@ const getSignature = (file, callback) => {
   })
 }
 
-const getSignedStagingFile = getSignature.bind(null, `${name}.staging.min.js`)
-const getSignedProductionFile = getSignature.bind(null, `${name}.min.js`)
+const getSignedStagingFile = getSignature.bind(null, `${distPath}/${name}.staging.min.js`)
+const getSignedProductionFile = getSignature.bind(null, `${distPath}/${name}.min.js`)
 
 const updateChangelog = (versionedFile, signature, callback) => {
   fs.readFile('CHANGELOG.md', 'utf-8', (readErr, contents) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-helpers",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A collection of scripts that can be used as part of a deployment process.",
   "main": "src/utils",
   "bin": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,5 @@
 // utils for building, not needed in the built output
 
-const path = require('path')
 const childProcess = require('child_process')
 
 const devUtils = module.exports = {}
@@ -15,15 +14,13 @@ devUtils.getIntegrity = (file, callback) => {
 devUtils.createVersionedDistFile = (file, callback) => {
   if (!process.env.npm_package_version) return callback('Version missing - must run this as an npm script')
   const versionedFile = file.replace('.js', `.${process.env.npm_package_version}.js`)
-  const distPath = path.resolve(__dirname, '../dist')
-  const cmd = `cp ${distPath}/${file} ${distPath}/${versionedFile}`
+  const cmd = `cp ${file} ${versionedFile}`
   childProcess.exec(cmd, err => {
     callback(err, versionedFile)
   })
 }
 
 devUtils.getSignature = (file, callback) => {
-  const distPath = path.resolve(__dirname, '../dist')
-  const cmd = `cat ${distPath}/${file} | openssl dgst -sha256 -binary | openssl enc -base64 -A`
+  const cmd = `cat ${file} | openssl dgst -sha256 -binary | openssl enc -base64 -A`
   childProcess.exec(cmd, callback)
 }

--- a/test/unit/utilsTest.js
+++ b/test/unit/utilsTest.js
@@ -1,5 +1,4 @@
 const utils = require('../../src/utils')
-const path = require('path')
 const childProcess = require('child_process')
 
 describe('utils', function () {
@@ -16,7 +15,6 @@ describe('utils', function () {
     beforeEach(function () {
       callback = sandbox.stub()
       sandbox.stub(childProcess, 'exec')
-      sandbox.stub(path, 'resolve').returns('PATH')
     })
 
     describe('when we have version', function () {
@@ -28,7 +26,7 @@ describe('utils', function () {
 
       it('copies the file', function () {
         expect(childProcess.exec).to.have.been.calledOnce()
-          .and.calledWith('cp PATH/foo.js PATH/foo.VERSION.js')
+          .and.calledWith('cp foo.js foo.VERSION.js')
       })
 
       it('yields versioned file name', function () {
@@ -93,7 +91,6 @@ describe('utils', function () {
 
     beforeEach(function () {
       callback = sandbox.stub()
-      sandbox.stub(path, 'resolve')
       sandbox.stub(childProcess, 'exec').yields(null, 'SIGNATURE')
     })
 


### PR DESCRIPTION
left in __dir when I copied this from payframe, which made files relative to this script, instead of relative to cwd... moved the file around so it does what was originally intended now.