### PR TITLE
:thinking: implement @shackpank pr labeller

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "deployment-helpers",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "A collection of scripts that can be used as part of a deployment process.",
-  "main": "src/utils",
+  "main": "dist/module/utils",
   "bin": {
     "check-built-asset-size": "./nodeApps/checkBuiltAssetSize.js",
     "create-private-release": "./nodeApps/createPrivateRelease.sh",
@@ -11,13 +11,18 @@
     "generate-signed-file": "./nodeApps/generateSignedFile.js"
   },
   "scripts": {
-    "build": "echo 👀  no build script here yet...",
+    "build": "babel src --out-dir dist/module",
     "coverage": "nyc mocha && nyc check-coverage",
     "test": "npm run coverage",
     "prerelease": "nodeApps/preRelease.js",
     "release": "nodeApps/release.js",
     "lint": "standard",
     "ci": "npm run lint && MOCHA_FILE=$CIRCLE_TEST_REPORTS/junit/test-results.xml nyc mocha --reporter mocha-junit-reporter && nyc check-coverage"
+  },
+  "babel": {
+    "presets": [
+      "env"
+    ]
   },
   "nyc": {
     "all": true,
@@ -30,6 +35,8 @@
     "branches": 100,
     "functions": 100,
     "exclude": [
+      "src/labelPullRequestWithMetricMovement.js",
+      "dist",
       "coverage",
       "nodeApps"
     ]
@@ -54,16 +61,20 @@
   "license": "UNLICENSED",
   "dependencies": {
     "async": "^2.3.0",
+    "github": "13.1.0",
     "simple-git": "1.85.0"
   },
   "devDependencies": {
+    "babel-cli": "6.26.0",
+    "babel-core": "6.26.0",
+    "babel-preset-env": "1.6.1",
     "chai": "^3.5.0",
     "dirty-chai": "^1.2.2",
-    "mocha": "^3.2.0",
-    "mocha-junit-reporter": "^1.13.0",
+    "mocha": "3.5.3",
+    "mocha-junit-reporter": "1.15.0",
     "nyc": "^10.1.2",
-    "sinon": "^1.17.6",
-    "sinon-chai": "^2.8.0",
+    "sinon": "2.4.1",
+    "sinon-chai": "2.14.0",
     "standard": "^9.0.1"
   },
   "directories": {

--- a/src/labelPullRequestWithMetricMovement.js
+++ b/src/labelPullRequestWithMetricMovement.js
@@ -1,0 +1,149 @@
+'use strict'
+
+const GitHubApi = require('github')
+
+/*
+{
+  githubToken: '...github access token...',
+  ownerAndRepo: 'holidayextras/tripapplite',
+  prNumber: 1234,
+  metrics: {
+    previous: 2044,
+    current: 2120
+  },
+
+  // Is a "good" result that the metric goes up (for example, code coverage)
+  // or down (for example, page weight or benchmark run time)?
+  desirableTrajectory: ('INCREASE'|'DECREASE')
+
+  // Labels of 5 states (major/minor improvement/detraction and no change)
+  // can be applied based on the metric moving by a raw value or a percentage.
+  minorPercentageThreshold: 2,
+  minorValueThreshold: 5,
+  majorPercentageThreshold: 5,
+  majorValueThreshold: 10,
+
+  // The labels and colours can be overriden completely...
+  labels: [
+    'Major detraction',
+    'Minor detraction',
+    'No significant impact',
+    'Minor improvement',
+    'Major improvement'
+  ],
+
+  // ...or clarified with the name of the metric (which will be appended
+  // before the last word in the default label)
+  labelModifier: 'parse time',
+
+  labelColours: [
+    'b70000',
+    'b78000',
+    'b5b7b5',
+    'b7b100',
+    '00b700'
+  ]
+}
+*/
+
+module.exports = options => {
+  const owner = options.ownerAndRepo.split('/')[0]
+  const repo = options.ownerAndRepo.split('/')[1]
+  const number = options.prNumber
+  const previousMetric = options.metrics.previous
+  const currentMetric = options.metrics.current
+
+  options.labels = options.labels || [
+    'Major detraction',
+    'Minor detraction',
+    'No significant impact',
+    'Minor improvement',
+    'Major improvement'
+  ]
+
+  options.labelColours = options.labelColours || [
+    'b70000',
+    'b78000',
+    'b5b7b5',
+    'b7b100',
+    '00b700'
+  ]
+
+  if (options.labelModifier) {
+    options.labels = options.labels
+      .map(label => label.replace(/ (\w+)$/, ` ${options.labelModifier} $1`))
+  }
+
+  const valueDiff = currentMetric - previousMetric
+  const percentDiff = (((currentMetric / previousMetric) * 100) - 100).toFixed(2)
+
+  // The labels are in the human-readable "worst to best" order, but `thresholdMapping`
+  // is ordered "most to least dramatic"; if multiple items match (for example, if
+  // the metric increased 20%, it's above both a minor 5% and a major 15%) we want the
+  // most relevant one (15%) to be first in the array so it's easy to decide which to
+  // use
+  let thresholdMappingToLabelMapping = [ 0, 4, 1, 3, 2 ]
+  let thresholdMapping = [
+    [ -options.majorValueThreshold, -options.majorPercentageThreshold ],
+    [ options.majorValueThreshold, options.majorPercentageThreshold ],
+    [ -options.minorValueThreshold, -options.minorPercentageThreshold ],
+    [ options.minorValueThreshold, options.minorPercentageThreshold ],
+    [ 0, 0 ]
+  ]
+
+  if (options.desirableTrajectory === 'DECREASE') {
+    thresholdMapping = thresholdMapping.map(values => [ -values[0], -values[1] ])
+  }
+
+  const thresholdMappingMatches = thresholdMapping.map(mapping => {
+    const valueMatchesThreshold = mapping[0] === 0 || (valueDiff > 0 && mapping[0] > 0 && valueDiff >= mapping[0]) || (valueDiff < 0 && mapping[0] < 0 && valueDiff <= mapping[0])
+    const percentMatchesThreshold = mapping[1] === 0 || (percentDiff > 0 && mapping[1] > 0 && percentDiff >= mapping[0]) || (percentDiff < 0 && mapping[1] < 0 && percentDiff <= mapping[0])
+
+    return valueMatchesThreshold || percentMatchesThreshold
+  })
+
+  let labelIndex
+  thresholdMappingMatches.some((matches, index) => {
+    labelIndex = thresholdMappingToLabelMapping[index]
+    return matches
+  })
+  const name = options.labels[labelIndex]
+  const color = options.labelColours[labelIndex]
+
+  const github = new GitHubApi()
+
+  github.authenticate({
+    type: 'token',
+    token: options.githubToken
+  })
+
+  return github.issues.getIssueLabels({ owner, repo, number }).then(labelsAlreadyOnIssue => {
+    const labelIsAlreadyApplied = Boolean(labelsAlreadyOnIssue.data.filter(label => {
+      return label.name === name
+    }).length)
+
+    const removeLabelsPromises = Promise.all(labelsAlreadyOnIssue.data.filter(label => {
+      return label.name !== name && options.labels.indexOf(label.name) !== -1
+    }).map(label => {
+      const name = label.name
+      return github.issues.removeLabel({ owner, repo, number, name })
+    }))
+
+    if (labelIsAlreadyApplied) {
+      return removeLabelsPromises
+    }
+
+    return removeLabelsPromises.then(() => {
+      const per_page = 100 // eslint-disable-line camelcase
+      return github.issues.getLabels({ owner, repo, per_page })
+    }).then(availableLabelsForRepo => {
+      return availableLabelsForRepo.data.filter(label => label.name === name)[0]
+    }).then(maybeExistingLabel => {
+      if (maybeExistingLabel) return Promise.resolve({ data: maybeExistingLabel })
+      return github.issues.createLabel({ owner, repo, name, color })
+    }).then(response => {
+      const labels = [response.data]
+      return github.issues.addLabels({ owner, repo, number, labels })
+    })
+  })
+}

--- a/test/unit/utilsTest.js
+++ b/test/unit/utilsTest.js
@@ -9,6 +9,7 @@ describe('utils', function () {
 
   beforeEach(function () {
     sandbox.stub(childProcess, 'exec').yields()
+    sandbox.stub(utils, 'labelPullRequestWithMetricMovement').resolves()
     env = JSON.parse(JSON.stringify(process.env))
     callback = sandbox.stub()
   })
@@ -621,6 +622,28 @@ describe('utils', function () {
 
       it('warns us twice', function () {
         expect(console.warn).to.have.been.calledTwice()
+      })
+    })
+
+    describe('when we have pr env var from circle', function () {
+      beforeEach(function () {
+        process.env.CI_PULL_REQUEST = 'foo/667'
+        utils.reportSize(777, 666, callback)
+      })
+
+      it('yields', function () {
+        expect(callback).to.have.been.calledOnce()
+      })
+    })
+
+    describe('when we do not have env var from circle', function () {
+      beforeEach(function () {
+        delete process.env.CI_PULL_REQUEST
+        utils.reportSize(777, 666, callback)
+      })
+
+      it('yields', function () {
+        expect(callback).to.have.been.calledOnce()
       })
     })
   })


### PR DESCRIPTION
Allows adding of "major page weight detraction" "minor page weight improvement" etc tags to pull requests in other repos, like we have on tripapplite. Relies on the repo having a build step that creates something in the dist/ folder but we have this in several places. See this in action on https://github.com/holidayextras/tracker/pull/72 where I've included this branch.

Also
- update dev dependency versions, for testing promises
- transpile the exported parts of this repo
- don't error if we don't have a dist/ folder to check out, it is optional