### PR TITLE
:mouse: do not hardcode dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployment-helpers",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "A collection of scripts that can be used as part of a deployment process.",
   "platform": "custom",
   "owner": "tech-foundation",

--- a/src/utils.js
+++ b/src/utils.js
@@ -160,7 +160,7 @@ utils.addFile = (file, callback) => {
   utils.execAndIgnoreOutput(`git add ${file}`, callback)
 }
 
-utils.addDist = utils.addFile.bind(null, 'dist')
+utils.addDist = utils.addFile.bind(null, process.env.DIST_FOLDER)
 
 utils.addChangelog = utils.addFile.bind(null, 'CHANGELOG.md')
 
@@ -220,7 +220,7 @@ utils.confirmOnFeatureBranch = callback => {
 utils.getSize = (file, callback) => {
   fs.stat(file, (err, result) => {
     if (err || !result) {
-      console.warn('could not stat', file, 'did you not `npm run build`?')
+      console.warn('could not stat', file, 'did you not `npm run build`? or did you mean to set BUILT_ASSET?')
       return callback(err)
     }
     callback(null, result.size)


### PR DESCRIPTION
in most places I allowed dist/ to be overridden in case we were not using that folder
now in project-hxcm I am using a different dist/ folder for assets, but find
that dist is still hardcoded in one place... so fix that.

project lounge